### PR TITLE
Prepare for release v0.1.0-beta.4

### DIFF
--- a/Makefile.env
+++ b/Makefile.env
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MYSQL_REGISTRY=kubedb
-MYSQL_TAG=v0.7.0-beta.3
+MYSQL_TAG=v0.7.0-beta.4
 PERCONA_XTRADB_REGISTRY=kubedb
-PERCONA_XTRADB_TAG=v0.1.0-beta.3
+PERCONA_XTRADB_TAG=v0.1.0-beta.4
 KUBE_NAMESPACE=kube-system

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20201022103441-f51a42fb9ac8
 	kmodules.xyz/offshoot-api v0.0.0-20200922211229-36acc531abab
 	kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
-	kubedb.dev/apimachinery v0.14.0-beta.3.0.20201024022825-61b265325dc8
+	kubedb.dev/apimachinery v0.14.0-beta.4
 	stash.appscode.dev/apimachinery v0.11.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1581,8 +1581,8 @@ kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e h1:NASVP0dOE5Zdlq+3Op7Fh2
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e/go.mod h1:AZ58K5hrxkkNPf8tM+UWeZjtNG3/mn192nKcUyC93F8=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de h1:uWgv78OoOWx9eQdu6SEkPopvbpnL8WxZEMNd3/Oye2w=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de/go.mod h1:5A8s2nvrNAZGrt0OlsiiuZIik3xWyKW6+ZSwgljIm78=
-kubedb.dev/apimachinery v0.14.0-beta.3.0.20201024022825-61b265325dc8 h1:j1O9I4/af0Hu5Yc4GfGPG8SXicZt05rMhceOfpC10No=
-kubedb.dev/apimachinery v0.14.0-beta.3.0.20201024022825-61b265325dc8/go.mod h1:3/Dy8tn3ScoG3MnPKa8Ac0CDBqOuLo2r01BI3GVHgjM=
+kubedb.dev/apimachinery v0.14.0-beta.4 h1:DH2opKDzXpRUpvZQ7d1ezE/xLJjAFkIlGRJ2+kI2uZs=
+kubedb.dev/apimachinery v0.14.0-beta.4/go.mod h1:3/Dy8tn3ScoG3MnPKa8Ac0CDBqOuLo2r01BI3GVHgjM=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1131,7 +1131,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.3.0.20201024022825-61b265325dc8
+# kubedb.dev/apimachinery v0.14.0-beta.4
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.24-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/13
Signed-off-by: 1gtm <1gtm@appscode.com>